### PR TITLE
Support configurable system prompt path via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,10 @@ See the "Using web mode..." example above for a concrete transcript.
 - `CONSULT_LLM_ALLOWED_MODELS` - List of allowed models (optional)
   - Comma-separated list, e.g., `o3,gemini-3-pro-preview`
   - If not set, all models are available in MCP schema
+- `CONSULT_LLM_SYSTEM_PROMPT_PATH` - Custom path to system prompt file
+  (optional)
+  - Overrides the default `~/.consult-llm-mcp/SYSTEM_PROMPT.md` location
+  - Useful for project-specific prompts
 
 ### Custom system prompt
 
@@ -409,6 +413,19 @@ to customize how the consultant LLM behaves. The custom prompt is read on every
 request, so changes take effect immediately without restarting the server.
 
 To revert to the default prompt, simply delete the `SYSTEM_PROMPT.md` file.
+
+#### Custom prompt path
+
+Use `CONSULT_LLM_SYSTEM_PROMPT_PATH` to override the default prompt file
+location. This is useful for project-specific prompts that you can commit to
+your repository:
+
+```bash
+claude mcp add consult-llm \
+  -e GEMINI_API_KEY=your_key \
+  -e CONSULT_LLM_SYSTEM_PROMPT_PATH=/path/to/project/.consult-llm-mcp/SYSTEM_PROMPT.md \
+  -- npx -y consult-llm-mcp
+```
 
 ## MCP tool: consult_llm
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ const Config = z.object({
   codexReasoningEffort: z
     .enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh'])
     .optional(),
+  systemPromptPath: z.string().optional(),
 })
 
 export type Config = z.infer<typeof Config>
@@ -23,6 +24,7 @@ const parsedConfig = Config.safeParse({
   geminiMode: process.env.GEMINI_MODE,
   openaiMode: process.env.OPENAI_MODE,
   codexReasoningEffort: process.env.CODEX_REASONING_EFFORT,
+  systemPromptPath: process.env.CONSULT_LLM_SYSTEM_PROMPT_PATH,
 })
 
 if (!parsedConfig.success) {

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
+import { config } from './config.js'
 
 export const DEFAULT_SYSTEM_PROMPT = `You are an expert software engineering consultant analyzing code and technical problems. You are communicating with another AI system, not a human.
 
@@ -30,11 +31,9 @@ const CLI_MODE_SUFFIX = `
 IMPORTANT: Do not edit files yourself, only provide recommendations and code examples`
 
 export function getSystemPrompt(isCliMode: boolean): string {
-  const customPromptPath = join(
-    homedir(),
-    '.consult-llm-mcp',
-    'SYSTEM_PROMPT.md',
-  )
+  const customPromptPath =
+    config.systemPromptPath ??
+    join(homedir(), '.consult-llm-mcp', 'SYSTEM_PROMPT.md')
   let systemPrompt: string
 
   if (existsSync(customPromptPath)) {


### PR DESCRIPTION
## Summary
- Add `CONSULT_LLM_SYSTEM_PROMPT` env var to override the default `~/.consult-llm-mcp/SYSTEM_PROMPT.md` path
- Enables project-specific system prompts that can be committed to a repository

## Changes
- `src/config.ts`: Add `systemPromptPath` to Zod schema, read from `CONSULT_LLM_SYSTEM_PROMPT`
- `src/system-prompt.ts`: Use `config.systemPromptPath` with fallback to default path
- `README.md`: Document the new env var and usage

## Implementation
Follows existing patterns:
- Zod schema validation in `config.ts` with `z.string().optional()`
- Config imported via `import { config } from './config.js'`
- No semicolons, single quotes per `.prettierrc`

All checks pass (`npm run check`): lint, format, types, 42 tests.

Closes #2