### PR TITLE
feat: antigravity-cli backend (agy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ history
 consult-llm-darwin-*
 consult-llm-linux-*
 .consult-llm.local.yaml
+.antigravitycli/

--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ A **backend** is how `consult-llm` reaches that model family:
 | MiniMax      | yes           | `opencode`                             | `MINIMAX_API_KEY`   |
 | Anthropic    | yes           | none                                   | `ANTHROPIC_API_KEY` |
 | Grok         | yes           | none                                   | `XAI_API_KEY`       |
+| Antigravity  | no            | `antigravity-cli`                      | n/a (login via IDE) |
 
 ### API backend
 
@@ -493,6 +494,23 @@ consult-llm config set gemini.backend cursor-cli
 ```
 
 If your prompts need shell commands in Cursor CLI ask mode, allow them in `~/.cursor/cli-config.json`.
+
+**Antigravity CLI**: routes through `agy` (Google Antigravity CLI v1.0.3+). The
+active model is whatever you last picked in the Antigravity IDE — agy has no CLI
+flag for model selection. Single model ID: `agy`.
+
+```bash
+consult-llm config set antigravity.backend antigravity-cli
+
+# Optional: append extra args to every agy invocation. Shell-quoted.
+consult-llm config set antigravity.extra_args '--add-dir /path/to/extra'
+```
+
+Caveats: agy is an autonomous agent — with `--dangerously-skip-permissions`
+(which this backend passes) it can read/write files and run commands on its
+own before answering. Output mixes tool narration with the answer. No
+streaming JSON, no token-usage reporting, no thread IDs (only `--continue`
+for most-recent resume).
 
 **OpenCode**: routes through `opencode` to Copilot, OpenRouter, or other providers:
 

--- a/README.md
+++ b/README.md
@@ -509,8 +509,8 @@ consult-llm config set antigravity.extra_args '--add-dir /path/to/extra'
 Caveats: agy is an autonomous agent — with `--dangerously-skip-permissions`
 (which this backend passes) it can read/write files and run commands on its
 own before answering. Output mixes tool narration with the answer. No
-streaming JSON, no token-usage reporting, no thread IDs (only `--continue`
-for most-recent resume).
+streaming JSON, no token-usage reporting. Multi-turn threads are not
+supported (`-t` is rejected) because agy never prints conversation IDs.
 
 **OpenCode**: routes through `opencode` to Copilot, OpenRouter, or other providers:
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -422,11 +422,14 @@ minimax:
 grok:
   backend: api
   api_key: xai-test
+antigravity:
+  backend: antigravity-cli
+  extra_args: --add-dir /tmp
 opencode:
   default_provider: copilot
 "#;
         let cfg = ConfigFile::parse(yaml).expect("parses");
-        assert_eq!(cfg.providers.len(), 6);
+        assert_eq!(cfg.providers.len(), 7);
         for spec in PROVIDERS {
             assert!(
                 cfg.providers.contains_key(&spec.provider),
@@ -467,6 +470,8 @@ opencode:
             "--dangerously-bypass-approvals-and-sandbox"
         );
         assert_eq!(m["CONSULT_LLM_GEMINI_EXTRA_ARGS"], "--yolo");
+        assert_eq!(m["CONSULT_LLM_AGY_EXTRA_ARGS"], "--add-dir /tmp");
+        assert_eq!(m["CONSULT_LLM_ANTIGRAVITY_BACKEND"], "antigravity-cli");
         assert_eq!(m["CONSULT_LLM_OPENCODE_GEMINI_PROVIDER"], "google");
 
         // Opencode global default.

--- a/src/config/parse/mod.rs
+++ b/src/config/parse/mod.rs
@@ -32,6 +32,10 @@ pub fn parse_config(
         env("CONSULT_LLM_GEMINI_EXTRA_ARGS").as_deref(),
         "CONSULT_LLM_GEMINI_EXTRA_ARGS",
     )?;
+    let agy_extra_args = parse_extra_args(
+        env("CONSULT_LLM_AGY_EXTRA_ARGS").as_deref(),
+        "CONSULT_LLM_AGY_EXTRA_ARGS",
+    )?;
 
     let config = Config {
         providers,
@@ -40,6 +44,7 @@ pub fn parse_config(
         codex_reasoning_effort,
         codex_extra_args,
         gemini_extra_args,
+        agy_extra_args,
         api_idle_timeout,
         system_prompt_path: env("CONSULT_LLM_SYSTEM_PROMPT_PATH"),
         allowed_models: enabled_models.clone(),

--- a/src/config/parse/provider.rs
+++ b/src/config/parse/provider.rs
@@ -252,6 +252,7 @@ mod tests {
             Backend::GeminiCli,
             Backend::CursorCli,
             Backend::OpenCodeCli,
+            Backend::AntigravityCli,
         ];
         for b in &backends {
             assert_eq!(Backend::from_str(b.as_str()), Some(b.clone()));

--- a/src/config/parse/registry.rs
+++ b/src/config/parse/registry.rs
@@ -182,6 +182,7 @@ mod tests {
                 "MiniMax-M2.7",
                 "claude-opus-4-7",
                 "grok-4.3",
+                "agy",
             ]
         );
     }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -13,6 +13,7 @@ pub enum Backend {
     GeminiCli,
     CursorCli,
     OpenCodeCli,
+    AntigravityCli,
 }
 
 impl Backend {
@@ -23,6 +24,7 @@ impl Backend {
             "gemini-cli" => Some(Backend::GeminiCli),
             "cursor-cli" => Some(Backend::CursorCli),
             "opencode" => Some(Backend::OpenCodeCli),
+            "antigravity-cli" => Some(Backend::AntigravityCli),
             _ => None,
         }
     }
@@ -34,6 +36,7 @@ impl Backend {
             Backend::GeminiCli => "gemini-cli",
             Backend::CursorCli => "cursor-cli",
             Backend::OpenCodeCli => "opencode",
+            Backend::AntigravityCli => "antigravity-cli",
         }
     }
 }
@@ -55,6 +58,7 @@ pub struct Config {
     pub codex_reasoning_effort: String,
     pub codex_extra_args: Vec<String>,
     pub gemini_extra_args: Vec<String>,
+    pub agy_extra_args: Vec<String>,
     pub api_idle_timeout: Duration,
     pub system_prompt_path: Option<String>,
     pub allowed_models: Vec<String>,

--- a/src/executors/antigravity_cli.rs
+++ b/src/executors/antigravity_cli.rs
@@ -1,0 +1,127 @@
+//! Antigravity CLI (`agy`) executor — talks to Google's Antigravity IDE agent.
+//!
+//! agy v1.0.3 has **no public CLI flag for model selection**: the active model
+//! is whatever was last picked in the Antigravity IDE (persisted in
+//! `state.vscdb` as a protobuf blob). So this executor exposes a single `agy`
+//! model and assumes the user has set the right one in the IDE.
+//!
+//! Other limitations: agy only emits plain text on stdout (no JSON streaming,
+//! no tool/usage events, no session ID). The reducer is fed a single
+//! AssistantText per stdout line; tool narration ("I will list...") is passed
+//! through verbatim. Threads are limited to `--continue` (most-recent only)
+//! because agy never prints conversation IDs.
+
+use smallvec::smallvec;
+
+use super::stream::{ParsedStreamEvent, StreamEvents};
+use super::types::{ExecuteResult, ExecutionRequest, LlmExecutor, LlmExecutorCapabilities};
+use super::{append_file_refs, build_extra_dir_args, run_cli_executor};
+
+pub struct AntigravityCliExecutor {
+    capabilities: LlmExecutorCapabilities,
+    extra_args: Vec<String>,
+}
+
+impl AntigravityCliExecutor {
+    pub fn new(extra_args: Vec<String>) -> Self {
+        Self {
+            capabilities: LlmExecutorCapabilities {
+                is_cli: true,
+                // `--continue` resumes the most-recent conversation, but agy
+                // doesn't expose IDs so we can't pin a specific thread.
+                supports_threads: false,
+                supports_file_refs: true,
+            },
+            extra_args,
+        }
+    }
+}
+
+/// Each stdout line from agy is plain text. Pass it through as one
+/// AssistantText event so the reducer accumulates the full response.
+pub fn parse_agy_line(line: &str) -> StreamEvents {
+    if line.is_empty() {
+        return smallvec![];
+    }
+    smallvec![ParsedStreamEvent::AssistantText {
+        text: format!("{line}\n"),
+    }]
+}
+
+impl LlmExecutor for AntigravityCliExecutor {
+    fn capabilities(&self) -> &LlmExecutorCapabilities {
+        &self.capabilities
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "antigravity_cli"
+    }
+
+    fn execute(&self, req: ExecutionRequest) -> anyhow::Result<ExecuteResult> {
+        let ExecutionRequest {
+            prompt,
+            model: _,
+            system_prompt,
+            file_paths,
+            thread_id,
+            spool,
+        } = req;
+
+        let fps = file_paths.as_deref();
+        let message_with_files = append_file_refs(&prompt, fps);
+
+        // No persistent thread store on the consult side: `--continue` only
+        // resumes the most-recent conversation. When a thread_id was passed
+        // in we still ask agy to continue, but we can't pin a specific id.
+        let resume = thread_id.is_some();
+
+        let message = if resume {
+            message_with_files
+        } else {
+            format!("{system_prompt}\n\n{message_with_files}")
+        };
+
+        let mut args: Vec<String> = vec![
+            "--print".to_string(),
+            message,
+            "--dangerously-skip-permissions".to_string(),
+        ];
+
+        args.extend(build_extra_dir_args(fps, "--add-dir"));
+
+        if resume {
+            args.push("--continue".to_string());
+        }
+
+        args.extend(self.extra_args.iter().cloned());
+
+        run_cli_executor(
+            "agy",
+            &args,
+            "",
+            &prompt,
+            &system_prompt,
+            spool,
+            parse_agy_line,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_agy_line_passes_text_through() {
+        let events = parse_agy_line("Hello world");
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedStreamEvent::AssistantText { text } if text == "Hello world\n")
+        );
+    }
+
+    #[test]
+    fn parse_agy_line_empty_is_noop() {
+        assert!(parse_agy_line("").is_empty());
+    }
+}

--- a/src/executors/mod.rs
+++ b/src/executors/mod.rs
@@ -1,5 +1,6 @@
 pub mod anthropic_api;
 pub mod anthropic_events;
+pub mod antigravity_cli;
 pub mod api;
 pub mod api_chat;
 pub mod api_common;

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::config::{Backend, Config};
 use crate::executors::anthropic_api::AnthropicApiExecutor;
+use crate::executors::antigravity_cli::AntigravityCliExecutor;
 use crate::executors::api::ApiExecutor;
 use crate::executors::codex_cli::CodexCliExecutor;
 use crate::executors::cursor_cli::CursorCliExecutor;
@@ -102,6 +103,9 @@ impl ExecutorProvider {
             Backend::OpenCodeCli => {
                 let prefix = cfg.opencode_provider_for(provider).to_string();
                 Arc::new(OpenCodeCliExecutor::new(prefix))
+            }
+            Backend::AntigravityCli => {
+                Arc::new(AntigravityCliExecutor::new(cfg.agy_extra_args.clone()))
             }
         };
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -25,6 +25,7 @@ pub enum Provider {
     MiniMax,
     Anthropic,
     Grok,
+    Antigravity,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -123,6 +124,7 @@ pub const ALL_PROVIDERS: &[Provider] = &[
     Provider::MiniMax,
     Provider::Anthropic,
     Provider::Grok,
+    Provider::Antigravity,
 ];
 
 /// The provider registry. Order matters: `all_builtin_models()` flattens in this order,
@@ -283,6 +285,34 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         reasoning_effort_env: None,
         extra_args_env: None,
     },
+    // Antigravity CLI (`agy --print`). CLI-only — there is no public API and
+    // `agy` v1.0.3 has no CLI flag for model selection: the active model is
+    // whatever was last picked in the Antigravity IDE GUI (persisted under
+    // ~/Library/Application Support/Antigravity/.../state.vscdb). So we expose
+    // a single `agy` model; users switch model from the IDE side.
+    // `api_protocol` is a placeholder — only `antigravity-cli` is allowed.
+    ProviderSpec {
+        provider: Provider::Antigravity,
+        id: "antigravity",
+        model_prefixes: &["agy"],
+        api_base_url: None,
+        api_protocol: ApiProtocol::OpenAiCompat(OpenAiCompatRuntime {
+            extra_body: None,
+            think_tags: None,
+        }),
+        builtin_models: &["agy"],
+        selector_priorities: &["agy"],
+        api_key_env: "ANTIGRAVITY_API_KEY",
+        backend_env: "CONSULT_LLM_ANTIGRAVITY_BACKEND",
+        legacy_backend_env: None,
+        legacy_mode_env: None,
+        cli_backend_value: None,
+        allowed_backends: &["antigravity-cli"],
+        opencode_env: "CONSULT_LLM_OPENCODE_ANTIGRAVITY_PROVIDER",
+        default_opencode_provider: "antigravity",
+        reasoning_effort_env: None,
+        extra_args_env: Some("CONSULT_LLM_AGY_EXTRA_ARGS"),
+    },
 ];
 
 impl Provider {
@@ -362,6 +392,7 @@ mod tests {
             ("MiniMax-M2.7", Provider::MiniMax),
             ("claude-opus-4-7", Provider::Anthropic),
             ("grok-4.3", Provider::Grok),
+            ("agy", Provider::Antigravity),
         ];
 
         let builtins = all_builtin_models();
@@ -433,7 +464,10 @@ mod tests {
             }
             if let Some(env) = spec.extra_args_env {
                 assert!(!env.is_empty());
-                assert!(matches!(spec.provider, Provider::Gemini | Provider::OpenAI));
+                assert!(matches!(
+                    spec.provider,
+                    Provider::Gemini | Provider::OpenAI | Provider::Antigravity
+                ));
             }
         }
 


### PR DESCRIPTION
## Summary

Adds a new `antigravity-cli` backend that shells out to Google's `agy` CLI
(Antigravity IDE agent, currently v1.0.3). Exposes a single `agy` model under
a new `antigravity` provider.

## Known limitations of agy v1.0.3

These shape the backend's surface area; not bugs in the integration:

- **No CLI flag for model selection.** The active model is whatever was last
  picked in the Antigravity IDE GUI (persisted as a protobuf blob in
  `state.vscdb`). agy's `--help` does not list `--model`, and passing it
  errors with `flags provided but not defined: -model`. A `[--model=<flash_lite|flash|pro>] <prompt>`
  string exists in the binary but appears to be internal/unreachable. So
  consult-llm exposes a single `agy` model and users switch in the IDE.
- **Plain-text stdout only.** No JSON streaming, no tool events, no usage
  stats — so no token/cost reporting and tool narration ("I will list...")
  is passed through verbatim mixed with the answer.
- **No conversation IDs.** Threads limited to `--continue` (most-recent
  resume). `--conversation <id>` exists but IDs are never printed.
- **agy is an autonomous agent.** With `--dangerously-skip-permissions`
  (passed by this backend to avoid hanging on permission prompts), agy can
  read/write files and run commands on its own before answering.

## Usage

```bash
consult-llm config set antigravity.backend antigravity-cli
consult-llm -m agy "your prompt"
```

## Test plan

- [x] `cargo test` — 297 pass, 1 pre-existing XDG-discovery flake unrelated to this PR
- [x] `cargo clippy --release` — clean (one pre-existing `derivable_impls` warning)
- [x] End-to-end: `consult-llm -m agy "What is 2+2?"` → returns `4`
- [x] `consult-llm models` shows `agy` under `antigravity` selector
