### PR TITLE
Add per-provider base_url override for the api backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,22 @@ consult-llm config set openai.backend api
 consult-llm config set grok.backend api
 ```
 
+#### Custom base URL
+
+Any provider's API endpoint can be overridden with `base_url` (or the
+provider's `CONSULT_LLM_<PROVIDER>_BASE_URL` environment variable). Useful for
+proxies, gateways, and plan-specific endpoints. Not allowed in the committed
+project config (`.consult-llm.yaml`) because it controls where API credentials
+are sent.
+
+For example, Z.AI coding-plan subscription keys only work against the coding
+endpoint:
+
+```bash
+consult-llm config set zai.api_key your_zai_coding_plan_key
+consult-llm config set zai.base_url https://api.z.ai/api/coding/paas/v4
+```
+
 ### CLI backends
 
 Shell out to an already-installed local CLI. No API keys needed in `consult-llm`; authentication is handled by the CLI tool.
@@ -869,6 +885,7 @@ Environment variables override config file values.
 | `OPENROUTER_API_KEY`                       | OpenRouter API key                                                                      |                                                      |                                                      |
 | `XAI_API_KEY`                              | xAI API key for Grok models                                                             |                                                      |                                                      |
 | `ZAI_API_TOKEN`                            | Z.AI API key for GLM models                                                             |                                                      |                                                      |
+| `CONSULT_LLM_<PROVIDER>_BASE_URL`          | Override the API base URL for a provider's `api` backend (e.g. `CONSULT_LLM_ZAI_BASE_URL` for the Z.AI coding-plan endpoint) | URL                                                  | registry default                                     |
 | `CONSULT_LLM_DEFAULT_MODEL`                | Model or selector to use for single-response calls when `-m` is omitted                 | selector or exact model ID                           | first available                                      |
 | `CONSULT_LLM_DEFAULT_MODELS`               | Comma-separated ordered multi-model defaults when `-m` is omitted; duplicates preserved | selectors or exact model IDs                         | empty (falls through to default_model then fallback) |
 | `CONSULT_LLM_GEMINI_BACKEND`               | Backend for Gemini models                                                               | `api` `gemini-cli` `cursor-cli` `opencode` `profile` | `api`                                                |

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -201,6 +201,26 @@ mod tests {
     }
 
     #[test]
+    fn test_set_base_url_round_trips() {
+        let mut doc = mapping();
+        set_nested_key(
+            &mut doc,
+            "zai.base_url",
+            Value::String("https://api.z.ai/api/coding/paas/v4".into()),
+        )
+        .unwrap();
+        let out = serde_yaml::to_string(&doc).unwrap();
+        let cfg = ConfigFile::parse(&out).unwrap();
+        let m = cfg
+            .to_env_map(crate::config::file::ApiKeyPolicy::Allow)
+            .unwrap();
+        assert_eq!(
+            m["CONSULT_LLM_ZAI_BASE_URL"],
+            "https://api.z.ai/api/coding/paas/v4"
+        );
+    }
+
+    #[test]
     fn test_validate_key_rejects_empty_segments() {
         assert!(validate_key_path("").is_err());
         assert!(validate_key_path("gemini..backend").is_err());

--- a/src/cli/commands/doctor.rs
+++ b/src/cli/commands/doctor.rs
@@ -218,6 +218,7 @@ fn config_keys() -> Vec<&'static str> {
     ];
     for spec in PROVIDERS {
         keys.push(spec.backend_env);
+        keys.push(spec.base_url_env);
         keys.push(spec.cli_profile_env);
         keys.push(spec.opencode_env);
         if let Some(env) = spec.reasoning_effort_env {
@@ -244,6 +245,9 @@ fn semantic_name(env_key: &str) -> String {
             for spec in PROVIDERS {
                 if k == spec.backend_env {
                     return format!("{}.backend", spec.id);
+                }
+                if k == spec.base_url_env {
+                    return format!("{}.base_url", spec.id);
                 }
                 if k == spec.cli_profile_env {
                     return format!("{}.cli_profile", spec.id);

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -46,6 +46,10 @@ pub struct ProviderBlock {
     pub opencode_provider: Option<String>,
     pub reasoning_effort: Option<String>,
     pub api_key: Option<String>,
+    /// Override the API base URL for the `api` backend (e.g. the z.ai
+    /// coding-plan endpoint or a local proxy). Not allowed in the committed
+    /// project config because it controls where API credentials are sent.
+    pub base_url: Option<String>,
     /// Extra environment variables passed to the selected backend process or API transport.
     #[serde(default)]
     pub env: BTreeMap<String, String>,
@@ -77,6 +81,8 @@ pub enum ApiKeyPolicy {
 pub enum ProjectConfigPolicyError {
     /// An API key was set in the project config.
     ApiKey { provider: &'static str },
+    /// A base_url override was set in a provider block in the project config.
+    BaseUrl { provider: &'static str },
     /// A literal env value was set in a provider block in the project config.
     ProviderEnv { provider: &'static str },
     /// A literal env value was set in a CLI profile in the project config.
@@ -91,6 +97,15 @@ impl std::fmt::Display for ProjectConfigPolicyError {
                     f,
                     "API keys are not allowed in the shared project config (.consult-llm.yaml). \
                      Move `{}.api_key` to .consult-llm.local.yaml or ~/.config/consult-llm/config.yaml.",
+                    provider
+                )
+            }
+            ProjectConfigPolicyError::BaseUrl { provider } => {
+                write!(
+                    f,
+                    "base_url overrides are not allowed in the shared project config (.consult-llm.yaml) \
+                     because they control where API credentials are sent. \
+                     Move `{}.base_url` to .consult-llm.local.yaml or ~/.config/consult-llm/config.yaml.",
                     provider
                 )
             }
@@ -355,6 +370,17 @@ impl ConfigFile {
                 // blank/whitespace-only: silently skip (treat as unset)
             }
 
+            if let Some(v) = &block.base_url {
+                let trimmed = v.trim();
+                if !trimmed.is_empty() {
+                    if policy == ApiKeyPolicy::Forbid {
+                        return Err(ProjectConfigPolicyError::BaseUrl { provider: spec.id });
+                    }
+                    m.insert(spec.base_url_env.to_string(), trimmed.to_string());
+                }
+                // blank/whitespace-only: silently skip (treat as unset)
+            }
+
             if policy == ApiKeyPolicy::Forbid && !block.env.is_empty() {
                 return Err(ProjectConfigPolicyError::ProviderEnv { provider: spec.id });
             }
@@ -584,6 +610,7 @@ openrouter:
 zai:
   backend: profile
   cli_profile: claude-zai
+  base_url: https://api.z.ai/api/coding/paas/v4
 "#;
         let cfg = ConfigFile::parse(yaml).expect("parses");
         assert_eq!(cfg.providers.len(), 8);
@@ -647,6 +674,57 @@ zai:
 
         // Opencode global default.
         assert_eq!(m["CONSULT_LLM_OPENCODE_PROVIDER"], "copilot");
+
+        // base_url override lands at the spec-declared env name.
+        assert_eq!(
+            m["CONSULT_LLM_ZAI_BASE_URL"],
+            "https://api.z.ai/api/coding/paas/v4"
+        );
+    }
+
+    #[test]
+    fn test_base_url_maps_to_env() {
+        let cfg = cfg_with(vec![(
+            Provider::Zai,
+            ProviderBlock {
+                base_url: Some("https://api.z.ai/api/coding/paas/v4".into()),
+                ..Default::default()
+            },
+        )]);
+        let m = cfg.to_env_map(ApiKeyPolicy::Allow).unwrap();
+        assert_eq!(
+            m["CONSULT_LLM_ZAI_BASE_URL"],
+            "https://api.z.ai/api/coding/paas/v4"
+        );
+    }
+
+    #[test]
+    fn test_blank_base_url_skipped() {
+        let cfg = cfg_with(vec![(
+            Provider::Zai,
+            ProviderBlock {
+                base_url: Some("   ".into()),
+                ..Default::default()
+            },
+        )]);
+        let m = cfg.to_env_map(ApiKeyPolicy::Allow).unwrap();
+        assert!(!m.contains_key("CONSULT_LLM_ZAI_BASE_URL"));
+    }
+
+    #[test]
+    fn test_base_url_rejected_in_project_layer() {
+        let cfg = cfg_with(vec![(
+            Provider::Zai,
+            ProviderBlock {
+                base_url: Some("https://attacker.invalid/v1".into()),
+                ..Default::default()
+            },
+        )]);
+        let err = cfg.to_env_map(ApiKeyPolicy::Forbid).unwrap_err();
+        assert!(matches!(
+            err,
+            ProjectConfigPolicyError::BaseUrl { provider } if provider == "zai"
+        ));
     }
 
     #[test]

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -303,6 +303,43 @@ mod tests {
     }
 
     #[test]
+    fn test_base_url_in_project_config_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_path = write_yaml(
+            &dir,
+            "project.yaml",
+            "zai:\n  base_url: https://attacker.invalid/v1\n",
+        );
+        let paths = DiscoveredPaths {
+            user: None,
+            project: Some(project_path),
+            project_local: None,
+        };
+        match LayeredEnv::load(&paths) {
+            Ok(_) => panic!("expected error for base_url in project config"),
+            Err(err) => assert!(err.message.contains("base_url")),
+        }
+    }
+
+    #[test]
+    fn test_base_url_in_user_config_reaches_lookup() {
+        let dir = tempfile::tempdir().unwrap();
+        let user_path = write_yaml(
+            &dir,
+            "user.yaml",
+            "zai:\n  base_url: https://api.z.ai/api/coding/paas/v4\n",
+        );
+        let paths = DiscoveredPaths {
+            user: Some(user_path),
+            project: None,
+            project_local: None,
+        };
+        let env = LayeredEnv::load(&paths).unwrap();
+        let (val, _) = env.lookup("CONSULT_LLM_ZAI_BASE_URL").unwrap();
+        assert_eq!(val, "https://api.z.ai/api/coding/paas/v4");
+    }
+
+    #[test]
     fn test_api_key_in_user_config_loads_without_error() {
         let dir = tempfile::tempdir().unwrap();
         let user_path = write_yaml(&dir, "user.yaml", "gemini:\n  api_key: gm-key\n");

--- a/src/config/parse/mod.rs
+++ b/src/config/parse/mod.rs
@@ -101,6 +101,7 @@ pub(super) mod test_helpers {
                     *p,
                     ProviderRuntimeConfig {
                         api_key: key.map(|k| k.to_string()),
+                        base_url: None,
                         backend: backend.clone(),
                         opencode_provider: String::new(),
                         reasoning_effort: None,

--- a/src/config/parse/provider.rs
+++ b/src/config/parse/provider.rs
@@ -90,6 +90,11 @@ fn parse_provider_config(
     // 3. API key
     let api_key = env(spec.api_key_env);
 
+    // 3b. API base URL override
+    let base_url = env(spec.base_url_env)
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+
     // 4. OpenCode provider prefix
     let opencode_provider = env(spec.opencode_env)
         .or_else(|| opencode_global.clone())
@@ -130,6 +135,7 @@ fn parse_provider_config(
 
     Ok(ProviderRuntimeConfig {
         api_key,
+        base_url,
         backend,
         opencode_provider,
         reasoning_effort,
@@ -284,6 +290,45 @@ mod tests {
                 spec.provider
             );
         }
+    }
+
+    #[test]
+    fn test_base_url_override_from_env() {
+        let env = env_from(&[
+            ("ZAI_API_TOKEN", "zai-key"),
+            (
+                "CONSULT_LLM_ZAI_BASE_URL",
+                "https://api.z.ai/api/coding/paas/v4",
+            ),
+        ]);
+        let (config, _) = parse_config(env).unwrap();
+        assert_eq!(
+            config.api_base_url_for(Provider::Zai),
+            Some("https://api.z.ai/api/coding/paas/v4")
+        );
+    }
+
+    #[test]
+    fn test_base_url_defaults_to_registry() {
+        let env = env_from(&[("ZAI_API_TOKEN", "zai-key")]);
+        let (config, _) = parse_config(env).unwrap();
+        assert_eq!(
+            config.api_base_url_for(Provider::Zai),
+            Some("https://api.z.ai/api/paas/v4")
+        );
+    }
+
+    #[test]
+    fn test_whitespace_base_url_treated_as_unset() {
+        let env = env_from(&[
+            ("ZAI_API_TOKEN", "zai-key"),
+            ("CONSULT_LLM_ZAI_BASE_URL", "   "),
+        ]);
+        let (config, _) = parse_config(env).unwrap();
+        assert_eq!(
+            config.api_base_url_for(Provider::Zai),
+            Some("https://api.z.ai/api/paas/v4")
+        );
     }
 
     #[test]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -51,6 +51,7 @@ impl Backend {
 #[derive(Debug, Clone)]
 pub struct ProviderRuntimeConfig {
     pub api_key: Option<String>,
+    pub base_url: Option<String>,
     pub backend: Backend,
     pub opencode_provider: String,
     pub reasoning_effort: Option<String>,
@@ -189,6 +190,15 @@ impl Config {
     /// Get the API key for a provider (when using API backend).
     pub fn api_key_for(&self, provider: Provider) -> Option<&str> {
         self.providers[&provider].api_key.as_deref()
+    }
+
+    /// API base URL for a provider: the configured override when set,
+    /// otherwise the registry default (when using API backend).
+    pub fn api_base_url_for(&self, provider: Provider) -> Option<&str> {
+        self.providers[&provider]
+            .base_url
+            .as_deref()
+            .or_else(|| provider.api_base_url())
     }
 
     /// Get the OpenCode provider prefix for a provider family.

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -76,7 +76,7 @@ impl ExecutorProvider {
                 let key = cfg.api_key_for(provider).ok_or_else(|| {
                     anyhow::anyhow!("API key is required for {provider:?} models in API mode")
                 })?;
-                let base = provider.api_base_url().map(|s| s.to_string());
+                let base = cfg.api_base_url_for(provider).map(|s| s.to_string());
                 let idle_timeout = self.idle_timeout;
                 match provider.api_protocol() {
                     ApiProtocol::OpenAiCompat(runtime) => Arc::new(ApiExecutor::new(

--- a/src/models.rs
+++ b/src/models.rs
@@ -91,6 +91,9 @@ pub struct ProviderSpec {
     pub selector_priorities: &'static [&'static str],
     /// Env var for the API key (e.g. "OPENAI_API_KEY").
     pub api_key_env: &'static str,
+    /// Env var that overrides `api_base_url` for the `api` backend
+    /// (e.g. "CONSULT_LLM_OPENAI_BASE_URL").
+    pub base_url_env: &'static str,
     /// Prefixed backend env var (e.g. "CONSULT_LLM_OPENAI_BACKEND").
     pub backend_env: &'static str,
     /// Legacy unprefixed backend env var, if any (e.g. "OPENAI_BACKEND").
@@ -155,6 +158,7 @@ pub static PROVIDERS: &[ProviderSpec] = &[
             "gemini-2.5-pro",
         ],
         api_key_env: "GEMINI_API_KEY",
+        base_url_env: "CONSULT_LLM_GEMINI_BASE_URL",
         backend_env: "CONSULT_LLM_GEMINI_BACKEND",
         legacy_backend_env: Some("GEMINI_BACKEND"),
         legacy_mode_env: Some("GEMINI_MODE"),
@@ -179,6 +183,7 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         builtin_models: &["deepseek-v4-pro"],
         selector_priorities: &["deepseek-v4-pro"],
         api_key_env: "DEEPSEEK_API_KEY",
+        base_url_env: "CONSULT_LLM_DEEPSEEK_BASE_URL",
         backend_env: "CONSULT_LLM_DEEPSEEK_BACKEND",
         legacy_backend_env: None,
         legacy_mode_env: None,
@@ -217,6 +222,7 @@ pub static PROVIDERS: &[ProviderSpec] = &[
             "gpt-5.2-codex",
         ],
         api_key_env: "OPENAI_API_KEY",
+        base_url_env: "CONSULT_LLM_OPENAI_BASE_URL",
         backend_env: "CONSULT_LLM_OPENAI_BACKEND",
         legacy_backend_env: Some("OPENAI_BACKEND"),
         legacy_mode_env: Some("OPENAI_MODE"),
@@ -244,6 +250,7 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         builtin_models: &["MiniMax-M2.7"],
         selector_priorities: &["MiniMax-M2.7"],
         api_key_env: "MINIMAX_API_KEY",
+        base_url_env: "CONSULT_LLM_MINIMAX_BASE_URL",
         backend_env: "CONSULT_LLM_MINIMAX_BACKEND",
         legacy_backend_env: None,
         legacy_mode_env: None,
@@ -265,6 +272,7 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         builtin_models: &["claude-opus-4-7"],
         selector_priorities: &["claude-opus-4-7"],
         api_key_env: "ANTHROPIC_API_KEY",
+        base_url_env: "CONSULT_LLM_ANTHROPIC_BASE_URL",
         backend_env: "CONSULT_LLM_ANTHROPIC_BACKEND",
         legacy_backend_env: None,
         legacy_mode_env: None,
@@ -289,6 +297,7 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         builtin_models: &["grok-4.5", "grok-4.3"],
         selector_priorities: &["grok-4.5", "grok-4.3"],
         api_key_env: "XAI_API_KEY",
+        base_url_env: "CONSULT_LLM_GROK_BASE_URL",
         backend_env: "CONSULT_LLM_GROK_BACKEND",
         legacy_backend_env: None,
         legacy_mode_env: None,
@@ -313,6 +322,7 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         builtin_models: &["openrouter/auto"],
         selector_priorities: &["openrouter/auto"],
         api_key_env: "OPENROUTER_API_KEY",
+        base_url_env: "CONSULT_LLM_OPENROUTER_BASE_URL",
         backend_env: "CONSULT_LLM_OPENROUTER_BACKEND",
         legacy_backend_env: None,
         legacy_mode_env: None,
@@ -337,6 +347,7 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         builtin_models: &["glm-5.2"],
         selector_priorities: &["glm-5.2"],
         api_key_env: "ZAI_API_TOKEN",
+        base_url_env: "CONSULT_LLM_ZAI_BASE_URL",
         backend_env: "CONSULT_LLM_ZAI_BACKEND",
         legacy_backend_env: None,
         legacy_mode_env: None,


### PR DESCRIPTION
## Summary

Adds an optional `base_url` field to provider config blocks (and per-provider `CONSULT_LLM_<PROVIDER>_BASE_URL` env vars) that overrides the registry API endpoint for the `api` backend.

Motivation: z.ai coding-plan subscription keys only work against `https://api.z.ai/api/coding/paas/v4`, not the default pay-per-token endpoint. The override is generic, so it also covers proxies and gateways for any provider:

```bash
consult-llm config set zai.api_key <coding-plan-key>
consult-llm config set zai.base_url https://api.z.ai/api/coding/paas/v4
```

## Implementation

- `ProviderSpec.base_url_env`: explicit per-provider env name, following the `backend_env`/`cli_profile_env` pattern
- `Config::api_base_url_for()` returns the configured override with fallback to the static registry URL; the executor factory (`llm.rs`) uses it for both OpenAI-compat and Anthropic protocols
- **Rejected in the committed project config** (`.consult-llm.yaml`) via `ProjectConfigPolicyError::BaseUrl` — same threat model as `api_key`/provider `env`: a malicious repo must not be able to redirect user credentials to an attacker endpoint
- Blank/whitespace values treated as unset (same idiom as `reasoning_effort`)
- `doctor --verbose` surfaces the new keys; `config set <provider>.base_url` round-trips
- README: "Custom base URL" section + env table row

## Testing

- 9 new tests (`cargo test base_url`): env-map emission, project-config policy rejection, env-over-registry precedence, whitespace handling, loader layering, config-set round-trip, `deny_unknown_fields` YAML acceptance
- Full workspace suite passes (441 tests), `cargo fmt --check` clean; the single clippy warning (`useless_borrows_in_formatting` in `src/executors/api.rs`) predates this change and comes from the newer rustc 1.97 lint set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkaiqUNK1eSGHyEP9YhXMo