### PR TITLE
Add pi CLI backend and Kimi (Moonshot) provider family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added a `pi` CLI backend that routes any model family through [pi-coding-agent](https://github.com/earendil-works/pi-mono) (`pi --mode json`), with streamed text/tool events, accumulated token usage and cost, thread resume via `--session`, file context via `@file` args, and `reasoning_effort` mapped to `--thinking`.
+- Added the Kimi (Moonshot) model family (`kimi-k3`, `kimi-k2.7-code`) with `api`, `pi`, and `profile` backends. The `api` backend targets the Kimi for Coding endpoint (`https://api.kimi.com/coding/v1`) with `KIMI_API_KEY`; the `pi` backend routes through pi's `moonshot` provider.
+
 ## v3.0.30 (2026-08-14)
 
 - Kimi API models can now use the OpenAI provider with a custom OpenAI-compatible gateway. ([#19](https://github.com/raine/consult-llm/pull/19))

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For the more detailed flow, [continue below](#how-it-really-works).
 
 - **Get a second opinion from another model** from your agent with relevant file context (`/consult`)
 - **Have models debate the best approach** and synthesize a consensus (`/debate`)
-- **Use existing subscriptions** via CLI backends without API keys ([Gemini CLI](#gemini-cli), [Codex CLI](#codex-cli), [Cursor CLI](#cursor-cli), [Claude CLI](#profile-backend), [OpenCode](#opencode))
+- **Use existing subscriptions** via CLI backends without API keys ([Gemini CLI](#gemini-cli), [Codex CLI](#codex-cli), [Cursor CLI](#cursor-cli), [Claude CLI](#profile-backend), [OpenCode](#opencode), [Pi](#pi))
 - **Continue conversations across requests** with `thread_id`
 - **Copy prompts to clipboard** for browser-based LLMs (`--web`)
 - **[Monitor](#monitor) active and past runs** in a real-time TUI
@@ -428,16 +428,17 @@ A **backend** is how `consult-llm` reaches that model family:
 - **`api`**: direct HTTP calls using an API key
 - **CLI backends**: shell out to a local CLI tool already installed and logged in
 
-| Model family | `api` backend | CLI backends available                            | API key env var      |
-| ------------ | ------------- | ------------------------------------------------- | -------------------- |
-| Gemini       | yes           | `gemini-cli`, `cursor-cli`, `opencode`, `profile` | `GEMINI_API_KEY`     |
-| OpenAI       | yes           | `codex-cli`, `cursor-cli`, `opencode`, `profile`  | `OPENAI_API_KEY`     |
-| DeepSeek     | yes           | `opencode`, `profile`                             | `DEEPSEEK_API_KEY`   |
-| MiniMax      | yes           | `opencode`, `profile`                             | `MINIMAX_API_KEY`    |
-| Anthropic    | yes           | `profile`, `claude-cli`, `cursor-cli`             | `ANTHROPIC_API_KEY`  |
-| Grok         | yes           | `grok-cli`, `cursor-cli`, `profile`               | `XAI_API_KEY`        |
-| Zai (GLM)    | yes           | `profile`                                         | `ZAI_API_TOKEN`      |
-| OpenRouter   | yes           | `opencode`, `profile`                             | `OPENROUTER_API_KEY` |
+| Model family | `api` backend | CLI backends available                                 | API key env var      |
+| ------------ | ------------- | ------------------------------------------------------ | -------------------- |
+| Gemini       | yes           | `gemini-cli`, `cursor-cli`, `opencode`, `pi`, `profile` | `GEMINI_API_KEY`     |
+| OpenAI       | yes           | `codex-cli`, `cursor-cli`, `opencode`, `pi`, `profile`  | `OPENAI_API_KEY`     |
+| DeepSeek     | yes           | `opencode`, `pi`, `profile`                            | `DEEPSEEK_API_KEY`   |
+| MiniMax      | yes           | `opencode`, `pi`, `profile`                            | `MINIMAX_API_KEY`    |
+| Anthropic    | yes           | `profile`, `claude-cli`, `cursor-cli`, `pi`            | `ANTHROPIC_API_KEY`  |
+| Grok         | yes           | `grok-cli`, `cursor-cli`, `pi`, `profile`              | `XAI_API_KEY`        |
+| Zai (GLM)    | yes           | `pi`, `profile`                                        | `ZAI_API_TOKEN`      |
+| Kimi         | yes           | `pi`, `profile`                                        | `KIMI_API_KEY`       |
+| OpenRouter   | yes           | `opencode`, `pi`, `profile`                            | `OPENROUTER_API_KEY` |
 
 ### API backend
 
@@ -621,6 +622,18 @@ consult-llm config set opencode.default_provider copilot
 consult-llm config set openai.opencode_provider openai
 ```
 
+#### Pi
+
+Routes through [`pi`](https://github.com/earendil-works/pi-mono) (pi-coding-agent) to any provider it supports (Anthropic, OpenAI, Google, DeepSeek, MiniMax, xAI, OpenRouter, Z.AI):
+
+```bash
+consult-llm config set anthropic.backend pi
+consult-llm config set openai.backend pi
+consult-llm config set gemini.backend pi
+```
+
+No API key needed in consult-llm -- authentication is handled by your pi installation (`pi /login` or provider env vars). The model is passed as `--model <provider>/<id>` (e.g. `anthropic/claude-opus-5`); a configured `reasoning_effort` is passed as `--thinking <level>`. Threads are resumed with `--session <id>`.
+
 #### OpenRouter
 
 Routes `openrouter/*` models through OpenCode:
@@ -707,7 +720,7 @@ the conversation with full context from prior turns.
   use write-through caching for the payment endpoints.
 ```
 
-This works with Gemini CLI, Codex CLI, Cursor CLI, OpenCode, and Claude CLI. OpenCode sessions use a consult-llm-managed SQLite database per thread unless `OPENCODE_DB` is set in provider `env`; this avoids contention between unrelated parallel OpenCode runs while preserving resume for returned thread IDs. See the [debate skills](#skills) for multi-LLM workflows that use thread IDs to maintain context across debate rounds.
+This works with Gemini CLI, Codex CLI, Cursor CLI, OpenCode, Pi, and Claude CLI. OpenCode sessions use a consult-llm-managed SQLite database per thread unless `OPENCODE_DB` is set in provider `env`; this avoids contention between unrelated parallel OpenCode runs while preserving resume for returned thread IDs. See the [debate skills](#skills) for multi-LLM workflows that use thread IDs to maintain context across debate rounds.
 
 ### Config files
 
@@ -901,14 +914,15 @@ Environment variables override config file values.
 | `CONSULT_LLM_<PROVIDER>_BASE_URL`          | Override the API base URL for a provider's `api` backend (e.g. `CONSULT_LLM_ZAI_BASE_URL` for the Z.AI coding-plan endpoint) | URL                                                  | registry default                                     |
 | `CONSULT_LLM_DEFAULT_MODEL`                | Model or selector to use for single-response calls when `-m` is omitted                 | selector or exact model ID                           | first available                                      |
 | `CONSULT_LLM_DEFAULT_MODELS`               | Comma-separated ordered multi-model defaults when `-m` is omitted; duplicates preserved | selectors or exact model IDs                         | empty (falls through to default_model then fallback) |
-| `CONSULT_LLM_GEMINI_BACKEND`               | Backend for Gemini models                                                               | `api` `gemini-cli` `cursor-cli` `opencode` `profile` | `api`                                                |
-| `CONSULT_LLM_OPENAI_BACKEND`               | Backend for OpenAI models                                                               | `api` `codex-cli` `cursor-cli` `opencode` `profile`  | `api`                                                |
-| `CONSULT_LLM_DEEPSEEK_BACKEND`             | Backend for DeepSeek models                                                             | `api` `opencode` `profile`                           | `api`                                                |
-| `CONSULT_LLM_MINIMAX_BACKEND`              | Backend for MiniMax models                                                              | `api` `opencode` `profile`                           | `api`                                                |
-| `CONSULT_LLM_ANTHROPIC_BACKEND`            | Backend for Anthropic models                                                            | `api` `profile` `claude-cli` `cursor-cli`            | `api`                                                |
-| `CONSULT_LLM_GROK_BACKEND`                 | Backend for Grok models                                                                 | `api` `grok-cli` `cursor-cli` `profile`              | `api`                                                |
-| `CONSULT_LLM_ZAI_BACKEND`                  | Backend for Z.AI (GLM) models                                                           | `api` `profile`                                      | `api`                                                |
-| `CONSULT_LLM_OPENROUTER_BACKEND`           | Backend for OpenRouter models                                                           | `api` `opencode` `profile`                           | `api`                                                |
+| `CONSULT_LLM_GEMINI_BACKEND`               | Backend for Gemini models                                                               | `api` `gemini-cli` `cursor-cli` `opencode` `pi` `profile` | `api`                                                |
+| `CONSULT_LLM_OPENAI_BACKEND`               | Backend for OpenAI models                                                               | `api` `codex-cli` `cursor-cli` `opencode` `pi` `profile`  | `api`                                                |
+| `CONSULT_LLM_DEEPSEEK_BACKEND`             | Backend for DeepSeek models                                                             | `api` `opencode` `pi` `profile`                           | `api`                                                |
+| `CONSULT_LLM_MINIMAX_BACKEND`              | Backend for MiniMax models                                                              | `api` `opencode` `pi` `profile`                           | `api`                                                |
+| `CONSULT_LLM_ANTHROPIC_BACKEND`            | Backend for Anthropic models                                                            | `api` `profile` `claude-cli` `cursor-cli` `pi`            | `api`                                                |
+| `CONSULT_LLM_GROK_BACKEND`                 | Backend for Grok models                                                                 | `api` `grok-cli` `cursor-cli` `pi` `profile`              | `api`                                                |
+| `CONSULT_LLM_ZAI_BACKEND`                  | Backend for Z.AI (GLM) models                                                           | `api` `pi` `profile`                                      | `api`                                                |
+| `CONSULT_LLM_KIMI_BACKEND`                 | Backend for Kimi (Moonshot) models                                                      | `api` `pi` `profile`                                      | `api`                                                |
+| `CONSULT_LLM_OPENROUTER_BACKEND`           | Backend for OpenRouter models                                                           | `api` `opencode` `pi` `profile`                           | `api`                                                |
 | `CONSULT_LLM_ALLOWED_MODELS`               | Comma-separated allowlist; restricts which models are enabled                           | model IDs                                            | all                                                  |
 | `CONSULT_LLM_EXTRA_MODELS`                 | Comma-separated extra model IDs to add to the catalog                                   | model IDs                                            |                                                      |
 | `CONSULT_LLM_CODEX_REASONING_EFFORT`       | Reasoning effort for Codex CLI backend                                                  | `none` `minimal` `low` `medium` `high` `xhigh`       | `high`                                               |

--- a/src/cli/commands/doctor.rs
+++ b/src/cli/commands/doctor.rs
@@ -150,6 +150,7 @@ fn backend_binary(backend: &str) -> Option<&'static str> {
         "grok-cli" => Some("grok"),
         "cursor-cli" => Some("cursor-agent"),
         "opencode" => Some("opencode"),
+        "pi" => Some("pi"),
         "claude-cli" => Some("claude"),
         _ => None,
     }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -611,9 +611,12 @@ zai:
   backend: profile
   cli_profile: claude-zai
   base_url: https://api.z.ai/api/coding/paas/v4
+kimi:
+  backend: pi
+  api_key: kimi-test
 "#;
         let cfg = ConfigFile::parse(yaml).expect("parses");
-        assert_eq!(cfg.providers.len(), 8);
+        assert_eq!(cfg.providers.len(), 9);
         for spec in PROVIDERS {
             assert!(
                 cfg.providers.contains_key(&spec.provider),

--- a/src/config/parse/provider.rs
+++ b/src/config/parse/provider.rs
@@ -368,6 +368,7 @@ mod tests {
             Backend::GrokCli,
             Backend::CursorCli,
             Backend::OpenCodeCli,
+            Backend::PiCli,
             Backend::ClaudeCli,
             Backend::Profile,
         ];

--- a/src/config/parse/registry.rs
+++ b/src/config/parse/registry.rs
@@ -266,15 +266,21 @@ mod tests {
     }
 
     #[test]
-    fn test_extra_kimi_model_is_available_with_openai_api_backend() {
+    fn test_extra_kimi_model_is_available_with_kimi_api_backend() {
+        // Since the Kimi (Moonshot) provider family exists, kimi-* model IDs route to
+        // it instead of OpenAI; a custom OpenAI-compatible gateway is configured via
+        // CONSULT_LLM_KIMI_BASE_URL + KIMI_API_KEY (supersedes the #19 recipe).
         let env = env_from(&[
-            ("OPENAI_API_KEY", "key"),
-            ("CONSULT_LLM_EXTRA_MODELS", "kimi-k3"),
-            ("CONSULT_LLM_ALLOWED_MODELS", "kimi-k3"),
+            ("KIMI_API_KEY", "key"),
+            ("CONSULT_LLM_EXTRA_MODELS", "kimi-k2.5"),
+            ("CONSULT_LLM_ALLOWED_MODELS", "kimi-k2.5"),
         ]);
         let (_, registry) = parse_config(env).unwrap();
-        assert_eq!(registry.allowed_models, vec!["kimi-k3"]);
-        assert_eq!(registry.resolve_model(Some("kimi-k3")).unwrap(), "kimi-k3");
+        assert_eq!(registry.allowed_models, vec!["kimi-k2.5"]);
+        assert_eq!(
+            registry.resolve_model(Some("kimi-k2.5")).unwrap(),
+            "kimi-k2.5"
+        );
     }
 
     #[test]
@@ -303,6 +309,8 @@ mod tests {
                 "grok-4.3",
                 "openrouter/auto",
                 "glm-5.2",
+                "kimi-k3",
+                "kimi-k2.7-code",
             ]
         );
     }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -14,6 +14,7 @@ pub enum Backend {
     GrokCli,
     CursorCli,
     OpenCodeCli,
+    PiCli,
     ClaudeCli,
     Profile,
 }
@@ -27,6 +28,7 @@ impl Backend {
             "grok-cli" => Some(Backend::GrokCli),
             "cursor-cli" => Some(Backend::CursorCli),
             "opencode" => Some(Backend::OpenCodeCli),
+            "pi" => Some(Backend::PiCli),
             "claude-cli" => Some(Backend::ClaudeCli),
             "profile" => Some(Backend::Profile),
             _ => None,
@@ -41,6 +43,7 @@ impl Backend {
             Backend::GrokCli => "grok-cli",
             Backend::CursorCli => "cursor-cli",
             Backend::OpenCodeCli => "opencode",
+            Backend::PiCli => "pi",
             Backend::ClaudeCli => "claude-cli",
             Backend::Profile => "profile",
         }

--- a/src/executors/mod.rs
+++ b/src/executors/mod.rs
@@ -14,6 +14,7 @@ pub mod gemini_cli;
 pub mod grok_cli;
 pub mod opencode_cli;
 mod opencode_db;
+pub mod pi_cli;
 pub mod sse;
 pub mod stream;
 pub mod tag_splitter;

--- a/src/executors/pi_cli.rs
+++ b/src/executors/pi_cli.rs
@@ -1,0 +1,453 @@
+use super::stream::{
+    ParsedStreamEvent, StreamEvents, first_non_empty_string, parse_json_line, tool_label,
+};
+use super::types::{ExecuteResult, ExecutionRequest, LlmExecutor, LlmExecutorCapabilities};
+use super::{CliOutputParser, prepare_cli_request, run_cli_executor_with_env};
+
+pub struct PiCliExecutor {
+    capabilities: LlmExecutorCapabilities,
+    /// pi provider name (e.g. "anthropic", "google", "xai")
+    provider_prefix: String,
+    thinking: Option<String>,
+    env: std::collections::BTreeMap<String, String>,
+}
+
+impl PiCliExecutor {
+    pub fn new(
+        provider_prefix: String,
+        thinking: Option<String>,
+        env: std::collections::BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            capabilities: LlmExecutorCapabilities {
+                is_cli: true,
+                supports_threads: true,
+                supports_file_refs: true,
+            },
+            provider_prefix,
+            thinking,
+            env,
+        }
+    }
+}
+
+/// Stateful parser for `pi --mode json` output (one JSON event per line).
+///
+/// Usage is reported per assistant message (`message_end`); the parser
+/// accumulates it and emits running totals so the reducer ends up with the
+/// sum across all turns instead of the last message's slice.
+pub struct PiJsonParser {
+    prompt_tokens: u64,
+    completion_tokens: u64,
+    cost: f64,
+    seen_usage: bool,
+}
+
+impl PiJsonParser {
+    pub fn new() -> Self {
+        Self {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            cost: 0.0,
+            seen_usage: false,
+        }
+    }
+}
+
+impl Default for PiJsonParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CliOutputParser for PiJsonParser {
+    fn on_line(&mut self, line: &str) -> anyhow::Result<StreamEvents> {
+        use smallvec::smallvec;
+
+        let Some(event) = parse_json_line(line) else {
+            return Ok(smallvec![]);
+        };
+
+        let events = match event.get("type").and_then(|t| t.as_str()) {
+            Some("session") => {
+                if let Some(id) = event.get("id").and_then(|v| v.as_str()) {
+                    smallvec![ParsedStreamEvent::SessionStarted { id: id.to_string() }]
+                } else {
+                    smallvec![]
+                }
+            }
+            Some("message_update") => {
+                if let Some(delta) = event
+                    .get("assistantMessageEvent")
+                    .filter(|e| e.get("type").and_then(|t| t.as_str()) == Some("text_delta"))
+                    .and_then(|e| e.get("delta"))
+                    .and_then(|d| d.as_str())
+                {
+                    smallvec![ParsedStreamEvent::AssistantText {
+                        text: delta.to_string(),
+                    }]
+                } else {
+                    smallvec![]
+                }
+            }
+            Some("tool_execution_start") => {
+                let call_id = event
+                    .get("toolCallId")
+                    .and_then(|id| id.as_str())
+                    .unwrap_or("tool")
+                    .to_string();
+                let name = event
+                    .get("toolName")
+                    .and_then(|name| name.as_str())
+                    .unwrap_or("tool");
+                let detail = event.get("args").and_then(tool_detail);
+                smallvec![ParsedStreamEvent::ToolStarted {
+                    call_id,
+                    label: tool_label(name, detail.as_deref()),
+                }]
+            }
+            Some("tool_execution_end") => {
+                let call_id = event
+                    .get("toolCallId")
+                    .and_then(|id| id.as_str())
+                    .unwrap_or("tool")
+                    .to_string();
+                let is_error = event
+                    .get("isError")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                smallvec![ParsedStreamEvent::ToolFinished {
+                    call_id,
+                    success: !is_error,
+                    error: if is_error {
+                        event.get("result").and_then(error_text)
+                    } else {
+                        None
+                    },
+                }]
+            }
+            Some("message_end") => {
+                let usage = event
+                    .get("message")
+                    .filter(|m| m.get("role").and_then(|r| r.as_str()) == Some("assistant"))
+                    .and_then(|m| m.get("usage"));
+                if let Some(usage) = usage {
+                    self.prompt_tokens += usage.get("input").and_then(|v| v.as_u64()).unwrap_or(0);
+                    self.completion_tokens +=
+                        usage.get("output").and_then(|v| v.as_u64()).unwrap_or(0);
+                    self.cost += usage
+                        .get("cost")
+                        .and_then(|c| c.get("total"))
+                        .and_then(|t| t.as_f64())
+                        .unwrap_or(0.0);
+                    self.seen_usage = true;
+                    smallvec![ParsedStreamEvent::Usage {
+                        prompt_tokens: self.prompt_tokens,
+                        completion_tokens: self.completion_tokens,
+                        cost: Some(self.cost),
+                    }]
+                } else {
+                    smallvec![]
+                }
+            }
+            _ => smallvec![],
+        };
+        Ok(events)
+    }
+}
+
+fn error_text(result: &serde_json::Value) -> Option<String> {
+    result
+        .as_str()
+        .map(str::to_string)
+        .or_else(|| {
+            result
+                .get("message")
+                .and_then(|m| m.as_str())
+                .map(str::to_string)
+        })
+        .or_else(|| {
+            result
+                .get("content")
+                .and_then(|c| c.as_str())
+                .map(str::to_string)
+        })
+        .or_else(|| Some(result.to_string()).filter(|r| r != "null"))
+}
+
+fn tool_detail(args: &serde_json::Value) -> Option<String> {
+    first_non_empty_string(
+        args,
+        &[
+            "path",
+            "filePath",
+            "file_path",
+            "pattern",
+            "command",
+            "cmd",
+            "url",
+            "query",
+            "description",
+        ],
+    )
+}
+
+/// Map a configured reasoning effort to a `pi --thinking` level.
+/// pi accepts off|minimal|low|medium|high|xhigh|max; consult-llm's
+/// codex-style "none" maps to "off".
+fn thinking_level(effort: &str) -> String {
+    match effort {
+        "none" => "off".to_string(),
+        other => other.to_string(),
+    }
+}
+
+impl LlmExecutor for PiCliExecutor {
+    fn capabilities(&self) -> &LlmExecutorCapabilities {
+        &self.capabilities
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "pi_cli"
+    }
+
+    fn reasoning_effort(&self, _model: &str) -> Option<&str> {
+        self.thinking.as_deref()
+    }
+
+    fn execute(&self, req: ExecutionRequest) -> anyhow::Result<ExecuteResult> {
+        // Files are passed as `@path` positional args (pi loads them into
+        // context), so the prompt text itself needs no file references.
+        let prepared = prepare_cli_request(req, |text, _| text.to_string());
+        let tid = prepared.thread_id.as_deref();
+
+        let pi_model = if prepared
+            .model
+            .starts_with(&format!("{}/", self.provider_prefix))
+        {
+            // Model already includes the provider prefix
+            // (e.g. "openrouter/xiaomi/mimo-v2.5-pro" with prefix "openrouter").
+            prepared.model.to_string()
+        } else {
+            format!("{}/{}", self.provider_prefix, prepared.model)
+        };
+
+        let mut args: Vec<String> = vec![
+            "--mode".to_string(),
+            "json".to_string(),
+            "--model".to_string(),
+            pi_model,
+        ];
+
+        if let Some(effort) = &self.thinking {
+            args.push("--thinking".to_string());
+            args.push(thinking_level(effort));
+        }
+
+        if let Some(t) = tid {
+            args.push("--session".to_string());
+            args.push(t.to_string());
+        }
+
+        if let Some(fps) = prepared.file_paths.as_deref() {
+            for fp in fps {
+                args.push(format!("@{}", fp.display()));
+            }
+        }
+
+        let mut parser = PiJsonParser::new();
+        run_cli_executor_with_env(
+            "pi",
+            &args,
+            Some(&self.env),
+            Some(&prepared.stdin_prompt),
+            &prepared.prompt,
+            &prepared.system_prompt,
+            prepared.spool,
+            &mut parser,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executors::stream::StreamReducer;
+
+    fn parse_line(parser: &mut PiJsonParser, line: &str) -> StreamEvents {
+        parser.on_line(line).unwrap()
+    }
+
+    #[test]
+    fn test_parse_session_header() {
+        let mut p = PiJsonParser::new();
+        let events = parse_line(
+            &mut p,
+            r#"{"type":"session","version":3,"id":"1b0d1c7e-1234-4abc-9def-0123456789ab","timestamp":"2026-08-11T10:00:00.000Z","cwd":"/repo"}"#,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedStreamEvent::SessionStarted { id } if id == "1b0d1c7e-1234-4abc-9def-0123456789ab")
+        );
+    }
+
+    #[test]
+    fn test_parse_text_delta() {
+        let mut p = PiJsonParser::new();
+        let events = parse_line(
+            &mut p,
+            r#"{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"Hello"}}"#,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], ParsedStreamEvent::AssistantText { text } if text == "Hello"));
+    }
+
+    #[test]
+    fn test_parse_ignores_thinking_delta() {
+        let mut p = PiJsonParser::new();
+        let events = parse_line(
+            &mut p,
+            r#"{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","contentIndex":0,"delta":"hmm"}}"#,
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_parse_tool_execution_start() {
+        let mut p = PiJsonParser::new();
+        let events = parse_line(
+            &mut p,
+            r#"{"type":"tool_execution_start","toolCallId":"call_1","toolName":"read","args":{"path":"src/main.rs"}}"#,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedStreamEvent::ToolStarted { call_id, label } if call_id == "call_1" && label == "read src/main.rs")
+        );
+    }
+
+    #[test]
+    fn test_parse_tool_execution_end_success() {
+        let mut p = PiJsonParser::new();
+        let events = parse_line(
+            &mut p,
+            r#"{"type":"tool_execution_end","toolCallId":"call_1","toolName":"bash","result":{"content":[{"type":"text","text":"ok"}],"details":{}},"isError":false}"#,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedStreamEvent::ToolFinished { call_id, success, error } if call_id == "call_1" && *success && error.is_none())
+        );
+    }
+
+    #[test]
+    fn test_parse_tool_execution_end_error() {
+        let mut p = PiJsonParser::new();
+        let events = parse_line(
+            &mut p,
+            r#"{"type":"tool_execution_end","toolCallId":"call_1","toolName":"bash","result":{"message":"exit 1"},"isError":true}"#,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedStreamEvent::ToolFinished { call_id, success, error } if call_id == "call_1" && !*success && error.as_deref() == Some("exit 1"))
+        );
+    }
+
+    #[test]
+    fn test_usage_accumulates_across_messages() {
+        let mut p = PiJsonParser::new();
+        let events = parse_line(
+            &mut p,
+            r#"{"type":"message_end","message":{"role":"assistant","content":[],"usage":{"input":1000,"output":50,"cacheRead":0,"cacheWrite":0,"cost":{"total":0.01}}}}"#,
+        );
+        assert!(matches!(
+            &events[0],
+            ParsedStreamEvent::Usage { prompt_tokens: 1000, completion_tokens: 50, cost } if *cost == Some(0.01)
+        ));
+        let events = parse_line(
+            &mut p,
+            r#"{"type":"message_end","message":{"role":"assistant","content":[],"usage":{"input":2000,"output":70,"cacheRead":500,"cacheWrite":0,"cost":{"total":0.02}}}}"#,
+        );
+        assert!(matches!(
+            &events[0],
+            ParsedStreamEvent::Usage { prompt_tokens: 3000, completion_tokens: 120, cost } if *cost == Some(0.03)
+        ));
+    }
+
+    #[test]
+    fn test_parse_ignores_user_message_end() {
+        let mut p = PiJsonParser::new();
+        let events = parse_line(
+            &mut p,
+            r#"{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_parse_ignores_lifecycle_events() {
+        let mut p = PiJsonParser::new();
+        for line in [
+            r#"{"type":"agent_start"}"#,
+            r#"{"type":"turn_start"}"#,
+            r#"{"type":"message_start","message":{"role":"assistant","content":[]}}"#,
+            r#"{"type":"turn_end","message":{},"toolResults":[]}"#,
+            r#"{"type":"agent_end","messages":[]}"#,
+        ] {
+            assert!(parse_line(&mut p, line).is_empty(), "line: {line}");
+        }
+    }
+
+    #[test]
+    fn test_parse_empty_and_malformed() {
+        let mut p = PiJsonParser::new();
+        assert!(parse_line(&mut p, "").is_empty());
+        assert!(parse_line(&mut p, "  ").is_empty());
+        assert!(parse_line(&mut p, "not json").is_empty());
+    }
+
+    #[test]
+    fn test_thinking_level_maps_none_to_off() {
+        assert_eq!(thinking_level("none"), "off");
+        assert_eq!(thinking_level("high"), "high");
+        assert_eq!(thinking_level("xhigh"), "xhigh");
+    }
+
+    #[test]
+    fn test_pi_reasoning_effort_reports_thinking() {
+        let executor = PiCliExecutor::new(
+            "anthropic".into(),
+            Some("high".into()),
+            std::collections::BTreeMap::new(),
+        );
+        assert_eq!(executor.reasoning_effort("claude-opus-5"), Some("high"));
+    }
+
+    #[test]
+    fn test_reducer_full_sequence() {
+        let mut parser = PiJsonParser::new();
+        let mut reducer = StreamReducer::new(
+            std::sync::Arc::new(std::sync::Mutex::new(
+                consult_llm_core::monitoring::RunSpool::disabled(),
+            )),
+            None,
+            None,
+        );
+        let lines = vec![
+            r#"{"type":"session","version":3,"id":"abc-123","timestamp":"t","cwd":"/repo"}"#,
+            r#"{"type":"agent_start"}"#,
+            r#"{"type":"tool_execution_start","toolCallId":"call_1","toolName":"read","args":{"path":"src/main.rs"}}"#,
+            r#"{"type":"tool_execution_end","toolCallId":"call_1","toolName":"read","result":{"content":[]},"isError":false}"#,
+            r#"{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"4"}}"#,
+            r#"{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"4"}],"usage":{"input":15000,"output":1,"cacheRead":0,"cacheWrite":0,"cost":{"total":0.05}}}}"#,
+            r#"{"type":"agent_end","messages":[]}"#,
+        ];
+        for line in &lines {
+            reducer.process(parser.on_line(line).unwrap());
+        }
+        assert_eq!(reducer.thread_id, Some("abc-123".to_string()));
+        assert_eq!(reducer.response, "4");
+        let usage = reducer.usage.unwrap();
+        assert_eq!(usage.prompt_tokens, 15000);
+        assert_eq!(usage.completion_tokens, 1);
+        assert_eq!(usage.cost, Some(0.05));
+    }
+}

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -11,6 +11,7 @@ use crate::executors::cursor_cli::CursorCliExecutor;
 use crate::executors::gemini_cli::GeminiCliExecutor;
 use crate::executors::grok_cli::GrokCliExecutor;
 use crate::executors::opencode_cli::OpenCodeCliExecutor;
+use crate::executors::pi_cli::PiCliExecutor;
 use crate::executors::types::LlmExecutor;
 use crate::models::{ApiProtocol, Provider};
 
@@ -135,6 +136,15 @@ impl ExecutorProvider {
                     cfg.env_for(provider).clone(),
                 ))
             }
+            Backend::PiCli => {
+                let prefix = provider.spec().default_pi_provider.to_string();
+                let effort = cfg.reasoning_effort_for(provider).map(str::to_string);
+                Arc::new(PiCliExecutor::new(
+                    prefix,
+                    effort,
+                    cfg.env_for(provider).clone(),
+                ))
+            }
             Backend::Profile => {
                 let selected = cfg.selected_cli_profile_for(provider).ok_or_else(|| {
                     anyhow::anyhow!(
@@ -223,6 +233,31 @@ mod tests {
             .get_executor("claude-opus-5")
             .expect("should create claude cli executor");
         assert_eq!(executor.reasoning_effort("claude-opus-5"), Some("xhigh"));
+    }
+
+    #[test]
+    fn test_pi_cli_executor_is_created() {
+        let env = env_from(&[("CONSULT_LLM_ANTHROPIC_BACKEND", "pi")]);
+        let (config, _) = parse_config_with_cli_profiles(env, test_cli_profiles()).unwrap();
+        let provider = ExecutorProvider::new(Arc::new(config));
+        let executor = provider
+            .get_executor("claude-opus-5")
+            .expect("should create pi cli executor");
+        assert_eq!(executor.backend_name(), "pi_cli");
+    }
+
+    #[test]
+    fn test_pi_cli_executor_uses_configured_effort() {
+        let env = env_from(&[
+            ("CONSULT_LLM_ANTHROPIC_BACKEND", "pi"),
+            ("CONSULT_LLM_CLAUDE_REASONING_EFFORT", "high"),
+        ]);
+        let (config, _) = parse_config_with_cli_profiles(env, test_cli_profiles()).unwrap();
+        let provider = ExecutorProvider::new(Arc::new(config));
+        let executor = provider
+            .get_executor("claude-opus-5")
+            .expect("should create pi cli executor");
+        assert_eq!(executor.reasoning_effort("claude-opus-5"), Some("high"));
     }
 
     #[test]

--- a/src/models.rs
+++ b/src/models.rs
@@ -23,6 +23,7 @@ pub enum Provider {
     Grok,
     OpenRouter,
     Zai,
+    Kimi,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -108,6 +109,9 @@ pub struct ProviderSpec {
     pub opencode_env: &'static str,
     /// Default opencode provider prefix (e.g. "openai").
     pub default_opencode_provider: &'static str,
+    /// pi provider name used to build `--model <provider>/<id>` for the `pi` backend
+    /// (e.g. "google" for gemini models, "xai" for grok models).
+    pub default_pi_provider: &'static str,
     /// Env var that carries the YAML-block `reasoning_effort` value, if this provider
     /// exposes one.
     pub reasoning_effort_env: Option<&'static str>,
@@ -129,6 +133,7 @@ pub const ALL_PROVIDERS: &[Provider] = &[
     Provider::Grok,
     Provider::OpenRouter,
     Provider::Zai,
+    Provider::Kimi,
 ];
 
 /// The provider registry. Order matters: `all_builtin_models()` flattens in this order,
@@ -163,9 +168,17 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         legacy_backend_env: Some("GEMINI_BACKEND"),
         legacy_mode_env: Some("GEMINI_MODE"),
         cli_backend_value: Some("gemini-cli"),
-        allowed_backends: &["api", "gemini-cli", "cursor-cli", "opencode", "profile"],
+        allowed_backends: &[
+            "api",
+            "gemini-cli",
+            "cursor-cli",
+            "opencode",
+            "pi",
+            "profile",
+        ],
         opencode_env: "CONSULT_LLM_OPENCODE_GEMINI_PROVIDER",
         default_opencode_provider: "google",
+        default_pi_provider: "google",
         reasoning_effort_env: None,
         extra_args_env: Some("CONSULT_LLM_GEMINI_EXTRA_ARGS"),
         cli_profile_env: "CONSULT_LLM_GEMINI_CLI_PROFILE",
@@ -188,9 +201,10 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         legacy_backend_env: None,
         legacy_mode_env: None,
         cli_backend_value: None,
-        allowed_backends: &["api", "opencode", "profile"],
+        allowed_backends: &["api", "opencode", "pi", "profile"],
         opencode_env: "CONSULT_LLM_OPENCODE_DEEPSEEK_PROVIDER",
         default_opencode_provider: "deepseek",
+        default_pi_provider: "deepseek",
         reasoning_effort_env: None,
         extra_args_env: None,
         cli_profile_env: "CONSULT_LLM_DEEPSEEK_CLI_PROFILE",
@@ -199,7 +213,7 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         provider: Provider::OpenAI,
         cursor_model_prefixes: &["gpt-", "composer-", "auto", "kimi-"],
         id: "openai",
-        model_prefixes: &["gpt-", "kimi-"],
+        model_prefixes: &["gpt-"],
         api_base_url: None,
         api_protocol: ApiProtocol::OpenAiCompat(OpenAiCompatRuntime {
             extra_body: None,
@@ -227,9 +241,17 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         legacy_backend_env: Some("OPENAI_BACKEND"),
         legacy_mode_env: Some("OPENAI_MODE"),
         cli_backend_value: Some("codex-cli"),
-        allowed_backends: &["api", "codex-cli", "cursor-cli", "opencode", "profile"],
+        allowed_backends: &[
+            "api",
+            "codex-cli",
+            "cursor-cli",
+            "opencode",
+            "pi",
+            "profile",
+        ],
         opencode_env: "CONSULT_LLM_OPENCODE_OPENAI_PROVIDER",
         default_opencode_provider: "openai",
+        default_pi_provider: "openai",
         reasoning_effort_env: Some("CONSULT_LLM_CODEX_REASONING_EFFORT"),
         extra_args_env: Some("CONSULT_LLM_CODEX_EXTRA_ARGS"),
         cli_profile_env: "CONSULT_LLM_OPENAI_CLI_PROFILE",
@@ -255,9 +277,10 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         legacy_backend_env: None,
         legacy_mode_env: None,
         cli_backend_value: None,
-        allowed_backends: &["api", "opencode", "profile"],
+        allowed_backends: &["api", "opencode", "pi", "profile"],
         opencode_env: "CONSULT_LLM_OPENCODE_MINIMAX_PROVIDER",
         default_opencode_provider: "minimax",
+        default_pi_provider: "minimax",
         reasoning_effort_env: None,
         extra_args_env: None,
         cli_profile_env: "CONSULT_LLM_MINIMAX_CLI_PROFILE",
@@ -277,9 +300,10 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         legacy_backend_env: None,
         legacy_mode_env: None,
         cli_backend_value: None,
-        allowed_backends: &["api", "cursor-cli", "profile", "claude-cli"],
+        allowed_backends: &["api", "cursor-cli", "pi", "profile", "claude-cli"],
         opencode_env: "CONSULT_LLM_OPENCODE_ANTHROPIC_PROVIDER",
         default_opencode_provider: "anthropic",
+        default_pi_provider: "anthropic",
         reasoning_effort_env: Some("CONSULT_LLM_CLAUDE_REASONING_EFFORT"),
         extra_args_env: Some("CONSULT_LLM_CLAUDE_EXTRA_ARGS"),
         cli_profile_env: "CONSULT_LLM_ANTHROPIC_CLI_PROFILE",
@@ -302,9 +326,10 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         legacy_backend_env: None,
         legacy_mode_env: None,
         cli_backend_value: None,
-        allowed_backends: &["api", "grok-cli", "cursor-cli", "profile"],
+        allowed_backends: &["api", "grok-cli", "cursor-cli", "pi", "profile"],
         opencode_env: "CONSULT_LLM_OPENCODE_GROK_PROVIDER",
         default_opencode_provider: "xai",
+        default_pi_provider: "xai",
         reasoning_effort_env: Some("CONSULT_LLM_GROK_REASONING_EFFORT"),
         extra_args_env: Some("CONSULT_LLM_GROK_EXTRA_ARGS"),
         cli_profile_env: "CONSULT_LLM_GROK_CLI_PROFILE",
@@ -327,9 +352,10 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         legacy_backend_env: None,
         legacy_mode_env: None,
         cli_backend_value: None,
-        allowed_backends: &["api", "opencode", "profile"],
+        allowed_backends: &["api", "opencode", "pi", "profile"],
         opencode_env: "CONSULT_LLM_OPENCODE_OPENROUTER_PROVIDER",
         default_opencode_provider: "openrouter",
+        default_pi_provider: "openrouter",
         reasoning_effort_env: Some("CONSULT_LLM_OPENROUTER_REASONING_EFFORT"),
         extra_args_env: None,
         cli_profile_env: "CONSULT_LLM_OPENROUTER_CLI_PROFILE",
@@ -352,12 +378,39 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         legacy_backend_env: None,
         legacy_mode_env: None,
         cli_backend_value: None,
-        allowed_backends: &["api", "profile"],
+        allowed_backends: &["api", "pi", "profile"],
         opencode_env: "CONSULT_LLM_OPENCODE_ZAI_PROVIDER",
         default_opencode_provider: "zai",
+        default_pi_provider: "zai",
         reasoning_effort_env: None,
         extra_args_env: None,
         cli_profile_env: "CONSULT_LLM_ZAI_CLI_PROFILE",
+    },
+    ProviderSpec {
+        provider: Provider::Kimi,
+        cursor_model_prefixes: &[],
+        id: "kimi",
+        model_prefixes: &["kimi-"],
+        api_base_url: Some("https://api.kimi.com/coding/v1"),
+        api_protocol: ApiProtocol::OpenAiCompat(OpenAiCompatRuntime {
+            extra_body: None,
+            think_tags: None,
+        }),
+        builtin_models: &["kimi-k3", "kimi-k2.7-code"],
+        selector_priorities: &["kimi-k3", "kimi-k2.7-code"],
+        api_key_env: "KIMI_API_KEY",
+        base_url_env: "CONSULT_LLM_KIMI_BASE_URL",
+        backend_env: "CONSULT_LLM_KIMI_BACKEND",
+        legacy_backend_env: None,
+        legacy_mode_env: None,
+        cli_backend_value: None,
+        allowed_backends: &["api", "pi", "profile"],
+        opencode_env: "CONSULT_LLM_OPENCODE_KIMI_PROVIDER",
+        default_opencode_provider: "moonshot",
+        default_pi_provider: "moonshot",
+        reasoning_effort_env: None,
+        extra_args_env: None,
+        cli_profile_env: "CONSULT_LLM_KIMI_CLI_PROFILE",
     },
 ];
 
@@ -476,6 +529,8 @@ mod tests {
             ("grok-4.3", Provider::Grok),
             ("openrouter/auto", Provider::OpenRouter),
             ("glm-5.2", Provider::Zai),
+            ("kimi-k3", Provider::Kimi),
+            ("kimi-k2.7-code", Provider::Kimi),
         ];
 
         let builtins = all_builtin_models();
@@ -535,10 +590,20 @@ mod tests {
     }
 
     #[test]
-    fn kimi_api_models_route_to_openai_compatible_provider() {
+    fn kimi_api_models_route_to_kimi_provider() {
         for model in &["kimi-k2.5", "kimi-k3"] {
-            assert_eq!(Provider::from_model(model), Some(Provider::OpenAI));
+            assert_eq!(Provider::from_model(model), Some(Provider::Kimi));
         }
+    }
+
+    /// Cursor still serves kimi-* model IDs through its OpenAI-compatible gateway,
+    /// so cursor-reported kimi models keep routing to OpenAI (see #19).
+    #[test]
+    fn kimi_cursor_models_route_to_openai() {
+        assert_eq!(
+            Provider::from_cursor_model("kimi-k2.5"),
+            Some(Provider::OpenAI)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a `pi` CLI backend that routes any model family through [pi-coding-agent](https://github.com/earendil-works/pi-mono) (`pi --mode json`), and a Kimi (Moonshot) provider family so pi's custom `moonshot` provider (Kimi for Coding) is reachable through consult-llm selectors.

```bash
consult-llm config set anthropic.backend pi
consult-llm config set zai.backend pi
consult-llm config set kimi.backend pi
```

Motivation: pi supports subscription/OAuth auth for many providers (Anthropic, OpenAI, Google, xAI, OpenRouter, Z.AI, MiniMax, DeepSeek, plus custom providers from `~/.pi/agent/models.json`), so a single local CLI login unlocks every model family without per-provider API keys in consult-llm.

## Implementation

- New `src/executors/pi_cli.rs`: runs `pi --mode json --model <provider>/<id>` and parses the JSONL event stream — session header → `thread_id`, `text_delta` → assistant text, `tool_execution_start/end` → tool events, `message_end` → usage. Usage is **accumulated across all assistant messages** (input/output tokens + `cost.total`), since pi reports per-message rather than per-run totals.
- Threads resume via `--session <id>`; file context is passed as positional `@path` args (pi loads them into context); configured `reasoning_effort` maps to `--thinking <level>` (codex-style `none` → pi's `off`).
- `ProviderSpec.default_pi_provider` maps consult-llm provider families to pi provider names (gemini→`google`, grok→`xai`, kimi→`moonshot`, others match their ids); `pi` added to `allowed_backends` of all providers pi supports.
- New `Provider::Kimi` registry entry (`kimi-k3`, `kimi-k2.7-code`; selector `kimi` → `kimi-k3`): `api` backend targets the Kimi for Coding endpoint (`https://api.kimi.com/coding/v1`, `KIMI_API_KEY`), `pi` backend routes through pi's `moonshot` provider, `profile` as usual.
- `doctor` checks the `pi` binary; README backend tables + "Pi" section; CHANGELOG entry.

## Testing

- 14 new tests: parser unit tests (session header, text/thinking deltas, tool start/end, error extraction, usage accumulation across messages), `thinking_level` mapping, executor construction and effort passthrough in `llm.rs`, updated registry/golden fixtures for the Kimi provider.
- Full workspace suite passes (458 tests), `cargo fmt --check` clean; the single clippy warning (`useless_borrows_in_formatting` in `src/executors/api.rs`) predates this change and comes from the newer rustc 1.97 lint set.
- Live end-to-end against a real pi install (Z.AI + Kimi for Coding auth): basic calls, thread resume (`-t`), file context (`-f`), multi-model run (`-m zai -m kimi`), `doctor` rows, and clean error propagation for unauthenticated providers.

🤖 Generated with [pi](https://github.com/earendil-works/pi-mono)
