### PR TITLE
feat(models): support Kimi API models

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,19 @@ consult-llm config set zai.api_key your_zai_coding_plan_key
 consult-llm config set zai.base_url https://api.z.ai/api/coding/paas/v4
 ```
 
+Kimi models served by an OpenAI-compatible gateway can use the OpenAI provider
+with an extra model entry and a custom endpoint:
+
+```yaml
+extra_models: [kimi-k3]
+allowed_models: [kimi-k3]
+
+openai:
+  backend: api
+  api_key: your_gateway_key
+  base_url: https://your-gateway.example/v1
+```
+
 ### CLI backends
 
 Shell out to an already-installed local CLI. No API keys needed in `consult-llm`; authentication is handled by the CLI tool.

--- a/src/config/parse/registry.rs
+++ b/src/config/parse/registry.rs
@@ -266,6 +266,18 @@ mod tests {
     }
 
     #[test]
+    fn test_extra_kimi_model_is_available_with_openai_api_backend() {
+        let env = env_from(&[
+            ("OPENAI_API_KEY", "key"),
+            ("CONSULT_LLM_EXTRA_MODELS", "kimi-k3"),
+            ("CONSULT_LLM_ALLOWED_MODELS", "kimi-k3"),
+        ]);
+        let (_, registry) = parse_config(env).unwrap();
+        assert_eq!(registry.allowed_models, vec!["kimi-k3"]);
+        assert_eq!(registry.resolve_model(Some("kimi-k3")).unwrap(), "kimi-k3");
+    }
+
+    #[test]
     fn test_all_builtin_models_order() {
         // Verify the model catalog order matches the original ALL_MODELS constant.
         // Order matters: enabled_models[0] is the fallback when gpt-5.2 is absent.

--- a/src/models.rs
+++ b/src/models.rs
@@ -199,7 +199,7 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         provider: Provider::OpenAI,
         cursor_model_prefixes: &["gpt-", "composer-", "auto", "kimi-"],
         id: "openai",
-        model_prefixes: &["gpt-"],
+        model_prefixes: &["gpt-", "kimi-"],
         api_base_url: None,
         api_protocol: ApiProtocol::OpenAiCompat(OpenAiCompatRuntime {
             extra_body: None,
@@ -531,6 +531,13 @@ mod tests {
 
         for (model, want) in expected {
             assert_eq!(Provider::from_cursor_model(model), Some(*want));
+        }
+    }
+
+    #[test]
+    fn kimi_api_models_route_to_openai_compatible_provider() {
+        for model in &["kimi-k2.5", "kimi-k3"] {
+            assert_eq!(Provider::from_model(model), Some(Provider::OpenAI));
         }
     }
 


### PR DESCRIPTION
## What changed

- recognize `kimi-*` model IDs as OpenAI-compatible API models
- document configuring Kimi through a custom gateway with `extra_models`
- cover provider routing and config availability with focused tests

## Why

Kimi models are already recognized when returned by Cursor, but the direct API path drops the same model IDs as an unrecognized provider prefix. OpenAI-compatible gateways can serve Kimi successfully through the existing API executor, so the direct path should accept the prefix as well.

Kimi remains opt-in through `extra_models`; it is not added to the built-in catalog because the default OpenAI endpoint does not serve it.

## Validation

- `cargo fmt --check`
- `cargo test` (`407 passed`)
- live gateway smoke test with `kimi-k3` through the OpenAI-compatible executor
